### PR TITLE
set Z-index to 0 when submenu appears

### DIFF
--- a/index.css
+++ b/index.css
@@ -35,6 +35,7 @@ nav {
   }
   .hidden.expose {
     margin-top: 0;
+    z-index: 0;
   }
   
   


### PR DESCRIPTION
Hey Ted -- when I put your hamburger menu on my page I found that the hidden submenu wasn't clickable unless I set the z-index to 0. Thought I'd send you the pull request to practice.

Thanks for the menu -- looks great!

Charles